### PR TITLE
eslint が absolute import だけでグルーピングするようにした

### DIFF
--- a/workspaces/editor/.eslintrc.js
+++ b/workspaces/editor/.eslintrc.js
@@ -28,12 +28,30 @@ module.exports = {
     plugins: ['react', '@typescript-eslint', 'prettier', 'simple-import-sort'],
     rules: {
         'eol-last': ['error', 'always'],
-        indent: ['error', 4,{"SwitchCase": 1}],
+        indent: ['error', 4, { SwitchCase: 1 }],
         'linebreak-style': ['error', 'unix'],
         quotes: ['error', 'single'],
         semi: ['error', 'always'],
 
-        'simple-import-sort/sort': 'error',
+        'simple-import-sort/sort': [
+            'error',
+            {
+                groups: [
+                    // Side effect imports.
+                    ['^\\u0000'],
+                    // Packages.
+                    // Things that start with a letter (or digit or underscore), or `@` followed by a letter.
+                    ['^@?\\w'],
+                    // Anything that does not start with a dot.
+                    ['^[^.]'],
+                    //  Absolute imports.
+                    ['^src/'],
+                    // Relative imports.
+                    // Anything that starts with a dot.
+                    ['^\\.'],
+                ],
+            },
+        ],
 
         '@typescript-eslint/explicit-function-return-type': 'error',
         // FIXME:


### PR DESCRIPTION
Fixes #58 

- package import とは区別してグルーピングするようになった
- `simple-import-sort` の `groups` オプションを変更した

参考：https://github.com/lydell/eslint-plugin-simple-import-sort#custom-grouping