### PR TITLE
動作確認に使用している Rust のバージョンについて追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Functional visual programming environment
 ## Requirements
 
 - yarn
-- Rust
+- Rust (1.41 or later)
 - (If you use Windows, install [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/#) manually)
 
 ## Install dependencies


### PR DESCRIPTION
<!-- (手順1) 以下の項目は、必ず記載してください -->

概要
---
wasm-pack, interp-core, interp-if とそれぞれの依存クレートのビルドに使用する Rust コンパイラの推奨バージョンが不明瞭だったので README に追記した

変更項目
---

↑の通り

<!-- (手順2) 以下の項目は、必要があれば記載してください -->

関連リンク
---

スクリーンショット
---

<!-- お疲れさまでした -->
