### PR TITLE
Implement exec() function partially (interp-if)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,8 +20,16 @@ version = "0.1.0"
 dependencies = [
  "interp-core 0.1.0",
  "js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "js-sys"
@@ -58,6 +66,36 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde_derive"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -127,11 +165,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum bumpalo 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5fb8038c1ddc0a5f73787b130f4cc75151e96ed33e417fde765eb5a81e3532f4"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+"checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 "checksum js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)" = "7889c7c36282151f6bf465be4700359318aef36baa951462382eae49e9577cf9"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3acb317c6ff86a4e579dfa00fc5e6cca91ecbb4e7eb2df0468805b674eb88548"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
+"checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
+"checksum serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
+"checksum serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
+"checksum serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)" = "9371ade75d4c2d6cb154141b9752cf3781ec9c05e0e5cf35060e1e70ee7b9c25"
 "checksum syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "af6f3550d8dff9ef7dc34d384ac6f107e5d31c8f57d9f28e0081503f547ac8f5"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "5205e9afdf42282b192e2310a5b463a6d1c1d774e30dc3c791ac37ab42d2616c"

--- a/workspaces/editor/src/bootstrap.tsx
+++ b/workspaces/editor/src/bootstrap.tsx
@@ -23,15 +23,15 @@ ReactDOM.render(
     document.getElementById('app')!
 );
 
-const subject = new Subject<number>();
+const errorSubject = new Subject<Error>();
 
-subject.subscribe({
-    next(value: number) {
-        console.log(`Received: ${value}`);
+errorSubject.subscribe({
+    next(err: Error) {
+        console.error(err);
     },
 });
 
 import('../interp-wasm').then(module => {
-    module.greet('Rust');
-    module.apply((n: number) => subject.next(n));
+    const error = (err: Error): void => errorSubject.next(err);
+    module.exec(error, JSON.stringify({ _type: 'lit_int', val: 42 }));
 });

--- a/workspaces/interp-if/Cargo.toml
+++ b/workspaces/interp-if/Cargo.toml
@@ -12,4 +12,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 interp-core = { path = "../interp-core" }
 js-sys = "0.3"
+serde = "1.0"
+serde_derive = "1.0"
+serde_json = "1.0"
 wasm-bindgen = "0.2"

--- a/workspaces/interp-if/src/lib.rs
+++ b/workspaces/interp-if/src/lib.rs
@@ -1,21 +1,39 @@
 extern crate interp_core;
 extern crate js_sys;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde_json;
 extern crate wasm_bindgen;
 
-use interp_core::add;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 extern "C" {
-    pub fn alert(s: &str);
+    #[wasm_bindgen(js_namespace = console)]
+    fn info(s: &str);
 }
 
-#[wasm_bindgen]
-pub fn greet(name: &str) {
-    alert(&format!("Hello, {}!", name));
+/// Intermediate representation between JSON string and `interp_core::syntax::Expr` enum
+#[derive(Debug, Deserialize)]
+struct JsonAst {
+    _type: String,
+    val: serde_json::Value,
 }
 
+/// The `exec()` function executes program written in JSON
 #[wasm_bindgen]
-pub fn apply(f: &js_sys::Function) {
-    let _ = f.call1(&JsValue::NULL, &JsValue::from(add(3, 4)));
+pub fn exec(err: &js_sys::Function, json_str: &str) {
+    let json_ast = serde_json::from_str::<JsonAst>(json_str).unwrap_or_else(|_| {
+        err.call1(
+            &JsValue::NULL,
+            &js_sys::Error::new("failed to convert JSON string into JsonAst"),
+        )
+        .ok();
+        panic!(); // FIXME: consider setting panic hook
+    });
+
+    info(format!("_type: {}", json_ast._type).as_str());
+    info(format!("val: {}", json_ast.val).as_str());
+
+    // TODO: convert JsonAst into interp_core::syntax::Expr and reduce it
 }


### PR DESCRIPTION
Fix part of #93 (DO NOT close yet)

<!-- (手順1) 以下の項目は、必ず記載してください -->

概要
---
js から JSON 文字列を interp-if に渡して、interp-if 側で struct に変換するところまでを実装した

変更項目
---
- JSON と Rust 側の内部表現との相互変換のために、`serde`, `serde_json`, `serde_derive` クレートを追加
- interp-if で必要ない(もともと動作確認用に定義した)関数の定義を削除
- JSON 文字列と `interp_core::syntax::Expr` の中間表現としての `JsonAst` struct を定義
- エラー情報を next / subscribe するための Subject を js 側に追加 (実行中にエラーが発生した場合には、interp-if がここにエラー情報を next する)
- `interp_if::exec` 関数を定義 (JSON 文字列を `JsonAst` に変換するところまで実装)
- 実際に js から exec 関数を呼び出して、パースできていることを確認するサンプルコードを追加

<!-- (手順2) 以下の項目は、必要があれば記載してください -->

関連リンク
---

スクリーンショット
---

<!-- お疲れさまでした -->
